### PR TITLE
Add oauth state validation

### DIFF
--- a/src/invidious/user/cookies.cr
+++ b/src/invidious/user/cookies.cr
@@ -37,5 +37,20 @@ struct Invidious::User
         samesite: HTTP::Cookie::SameSite::Lax
       )
     end
+
+    # Oauth2 State (OAUTH_STATE) cookie
+    # Parameter "domain" comes from the global config
+    def oauth_state(domain : String?, state) : HTTP::Cookie
+      return HTTP::Cookie.new(
+        name: "OAUTH_STATE",
+        domain: domain,
+        path: "/",
+        value: state,
+        expires: Time.utc + 2.years,
+        secure: SECURE,
+        http_only: true,
+        samesite: HTTP::Cookie::SameSite::Lax
+      )
+    end
   end
 end


### PR DESCRIPTION
The state parameter is recommended and adding this was required to allow authentication against kanidm. Even better would be PKCE support, but I'm not sure the state of that in the Crystal libraries.

Feel free to rework things and/or squash this in to any of your commits if that makes things easier to get merged upstream.